### PR TITLE
fix: 乱破配装格式错误

### DIFF
--- a/src/game/sr/data/characterData.json
+++ b/src/game/sr/data/characterData.json
@@ -2866,7 +2866,7 @@
             "set": [],
             "setList": [
                 ["IronCavalryAgainsttheScourge", "TaliaKingdomofBanditry"],
-                [["IronCavalryAgainsttheScourge", "ForgeoftheKalpagniLantern"]]
+                ["IronCavalryAgainsttheScourge", "ForgeoftheKalpagniLantern"]
             ],
             "main": {
                 "Body": [],


### PR DESCRIPTION
这导致了无法导入星铁遗器